### PR TITLE
 Create Rest API for Team

### DIFF
--- a/src/main/java/io/project/ipldashboard/controller/TeamController.java
+++ b/src/main/java/io/project/ipldashboard/controller/TeamController.java
@@ -1,0 +1,24 @@
+package io.project.ipldashboard.controller;
+
+import io.project.ipldashboard.model.Team;
+import io.project.ipldashboard.repository.MatchRepository;
+import io.project.ipldashboard.repository.TeamRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TeamController {
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @GetMapping("/team/{teamName}")
+    public Team getTeam(@PathVariable String teamName) {
+        Team team = this.teamRepository.findByTeamName(teamName);
+        team.setMatches(this.matchRepository.getLatestMatchesUsingCount(teamName, 4));
+        return team;
+    }
+}

--- a/src/main/java/io/project/ipldashboard/model/Team.java
+++ b/src/main/java/io/project/ipldashboard/model/Team.java
@@ -1,9 +1,7 @@
 package io.project.ipldashboard.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.List;
 
 @Entity
 public class Team {
@@ -13,6 +11,12 @@ public class Team {
     private String teamName;
     private long totalMatches;
     private long totalWins;
+    @Transient
+    private List<Match> matches;
+
+    public Team() {
+
+    }
 
     public Team(String teamName, long totalMatches) {
         this.teamName = teamName;
@@ -58,5 +62,13 @@ public class Team {
 
     public void setTotalWins(long totalWins) {
         this.totalWins = totalWins;
+    }
+
+    public List<Match> getMatches() {
+        return matches;
+    }
+
+    public void setMatches(List<Match> matches) {
+        this.matches = matches;
     }
 }

--- a/src/main/java/io/project/ipldashboard/repository/MatchRepository.java
+++ b/src/main/java/io/project/ipldashboard/repository/MatchRepository.java
@@ -1,0 +1,17 @@
+package io.project.ipldashboard.repository;
+
+import io.project.ipldashboard.model.Match;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface MatchRepository extends CrudRepository<Match, Long> {
+
+    List<Match> getByTeam1OrTeam2OrderByDateDesc(String teamName1, String teamName2, Pageable pageable);
+
+    default List<Match> getLatestMatchesUsingCount(String teamName, int count) {
+        return getByTeam1OrTeam2OrderByDateDesc(teamName, teamName, PageRequest.of(0, count));
+    }
+}

--- a/src/main/java/io/project/ipldashboard/repository/TeamRepository.java
+++ b/src/main/java/io/project/ipldashboard/repository/TeamRepository.java
@@ -1,0 +1,9 @@
+package io.project.ipldashboard.repository;
+
+import io.project.ipldashboard.model.Team;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TeamRepository extends CrudRepository<Team, Long> {
+
+    Team findByTeamName(String teamName);
+}


### PR DESCRIPTION
1. Create a Rest Controller for Team
   1.1 With endpoint for getting Team by its name.
2. Add corresponding TeamRepository
   2.1 to find Team object by its name in the database.
3. Add a transient instance member in Team Entity called List<Match> matches which is not persisted in Team table by JPA.
4. Create a MatchRepository interface which interacts with match table in database.
   4.1 add method to find a list of matches sorted by date in which a team played as a team1 or team2.
   4.2 add a default method which decouples MatchRepository from TeamController.